### PR TITLE
Limit pip deps to patch version updates

### DIFF
--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: "Install passlib"
   pip:
     name: 
-      - passlib
+      - passlib>=1.7.4,<1.8.0
 
 - name: Create prometheus group
   group:

--- a/roles/prometheus/tasks/prometheus-pve.yml
+++ b/roles/prometheus/tasks/prometheus-pve.yml
@@ -8,7 +8,7 @@
 - name: "Install prometheus-pve-exporter"
   pip:
     name: 
-      - prometheus-pve-exporter
+      - prometheus-pve-exporter>=2.2.3,<2.3.0
 
 - name: Create prometheus directory node config directory
   file:

--- a/roles/proxmox_server/tasks/main.yml
+++ b/roles/proxmox_server/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: "Install proxmoxer"
   pip:
-    name: proxmoxer 
+    name: proxmoxer>=1.3.1,<1.4.0
 
 - name: "Set KVM Credentials"
   set_fact:


### PR DESCRIPTION
Fixes #13

Pip dependencies are now version-locked. For security and reducing bugs, I've allowed patch updates to occur, but to improve reproducibility of deployments and avoid introducing new issues, minor and major version upgrades are not allowed. This means every so often someone needs to check changelogs and see if updates are needed. IMO this is better than running wild and having deployments using different software versions without us knowing.